### PR TITLE
modify 「回収忘」 to 「拾忘」

### DIFF
--- a/minarepoviewer/static/jsx/mrv.jsx
+++ b/minarepoviewer/static/jsx/mrv.jsx
@@ -76,7 +76,7 @@ var type2textShort = {
   'ps_kyun': '♡♡',
   'ps_disaster': '災害',
   'ps_zansa': '残渣',
-  'ps_kaisyuwasure': '回収忘',
+  'ps_kaisyuwasure': '拾忘',
   'ps_others': '他'
 };
 


### PR DESCRIPTION
レポ種類に表示されるテキストを修正しました．
3文字の「回収忘」を2文字の「拾忘」に変更
